### PR TITLE
IntelliJ-Haskell does not depend on intero

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Alternatives to HIE:
 
 ### [IntelliJ IDEA Community (setup difficulty easy)](https://www.jetbrains.com/idea/download/)
 
-* IntelliJ-Haskell (intero)
+* IntelliJ-Haskell
 * HaskForce
 * HoogleIt
 


### PR DESCRIPTION
The only prerequisite is stack.