### PR TITLE
WIP - 97 - `nwjs-sdk` should be installed on `nix-shell` run

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,15 @@
-with (import (builtins.fetchTarball {
-  url = "https://github.com/dmjio/miso/archive/561ffad.tar.gz";
-  sha256 = "1wwzckz2qxb873wdkwqmx9gmh0wshcdxi7gjwkba0q51jnkfdi41";
-}) {});
-with pkgs.haskell.packages;
-ghc865.callCabal2nix "haskell-editor-setup" ./. { miso = ghc865.miso-jsaddle; }
+let
+  ghcVersion = "ghc865";
+  misoPkgs = import (builtins.fetchTarball {
+    url = "https://github.com/dmjio/miso/archive/561ffad.tar.gz";
+    sha256 = "1wwzckz2qxb873wdkwqmx9gmh0wshcdxi7gjwkba0q51jnkfdi41";
+  }) {};
+in
+
+with misoPkgs.pkgs;
+with haskell.packages."${ghcVersion}";
+let app = callCabal2nix "haskell-editor-setup" ./. { miso = miso-jsaddle; };
+in  app.overrideAttrs (old: {
+  miso = miso-jsaddle;
+  buildInputs = old.buildInputs ++ [ nwjs-sdk ];
+})


### PR DESCRIPTION
fixes #97

**Notes**:
* changes testing workflow, if given merge between this and #96, which will need updating the contributing howto.
* (on NixOS) can be installed via `nix-env -f ./default.nix -i`, which brings #54 closer to completion. (E: maybe proper setup as well? With pinned nixpkgs, an overlay with our default.nix, a shell.nix and not using the nixpkgs from miso, or too much too fast?)
* (given previous point) what about `./hes`?